### PR TITLE
Fix Premature match on branch names

### DIFF
--- a/lib/status.js
+++ b/lib/status.js
@@ -26,12 +26,32 @@ function Status( options ) {
 }
 
 Status.parseBranch = function( line ) {
-  var pattern = /##\s+([^\s]+?)\.{3}(?:([^\s]+))?/
+  
+  // Handle <branch>[...<remote>]
+  var pattern = /##\s+([^\s]+?)(?:\.{3}|$)(?:([^\s]+))?/
   var info = pattern.exec( line )
-  return !info ? { index: 'initial commit' } : {
-    index: info[1],
-    remote: info[2]
+  
+  if( info != null ) {
+    return {
+      index: info[1],
+      remote: info[2]
+    }
   }
+  
+  // Handle repos in initial state
+  pattern = /##\s+Initial\s+commit\s+on\s+([^\s]+)/i
+  info = pattern.exec( line )
+  
+  if( info != null ) {
+    return {
+      index: info[1] + ':initial',
+      remote: null
+    }
+  }
+  
+  // Well, shit happened
+  return {}
+  
 }
 
 Status.parseStatus = function( line ) {


### PR DESCRIPTION
Fixes #4
- added handling of repositories in "initial commit" state
- added handling for branches which do not track a remote branch
- fixed my screw-ups while fixing this

Note: I'm sure there are still edge cases in states like "detached HEAD" etc, further testing needed though. Currently just eyeballing all the things.
