### PR TITLE
Fix error on Windows & exceeded maxBuffer

### DIFF
--- a/bin/dirty-git.js
+++ b/bin/dirty-git.js
@@ -29,6 +29,6 @@ var options = {
 if( !options.staged && !options.tree )
   options.tree = true
 
-dirty( program.path || process.cwd(), options )
+dirty( program.args.shift() || process.cwd(), options )
   .pipe( new format( options ) )
   .pipe( process.stdout )

--- a/lib/status.js
+++ b/lib/status.js
@@ -1,8 +1,28 @@
 var Stream = require( 'stream' )
 var inherit = require( 'derive' ).inherit
 var path = require( 'path' )
-var exec = require( 'child_process' ).execFile
+var spawn = require( 'child_process' ).spawn
 var lstat = require( 'fs' ).lstat
+
+function exec( cmd, argv, options, callback ) {
+  
+  var buffer = ''
+  
+  var child = spawn( cmd, argv, options )
+    .on( 'error', callback )
+    .on( 'close', function( code ) {
+      if( code !== 0 )
+        return callback(
+          new Error( 'Child process exited with code ' + code )
+        )
+      callback( null, buffer )
+    })
+  
+  child.stdout.on( 'data', function( chunk ) {
+    buffer += chunk
+  })
+  
+}
 
 /**
  * Status constructor

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "cli-color": "^0.3.2",
     "commander": "^2.3.0",
     "derive": "^2.3.0",
-    "glob-stream": "^3.1.14",
+    "glob-stream": "~4.0.0",
     "indent": "0.0.1"
   }
 }


### PR DESCRIPTION
Turns out that `child_process.exec()` & `child_process.execFile()` have an issue with sockets on Windows. The stacktrace show that it's running over node's `net` code, god knows why. Could probably be handled by `fs` with a regular named pipe, but I won't be digging into node core issues now. Anyways... that's what caused the `maxBuffer exceeded`.

The path thing is something I apparently forgot when I changed the usage from `<path>` to `[path]` during the very first rewrite or so... `program.path` isn't defined in this case.

- Fixes #6 
- Fixes #7 